### PR TITLE
Update QueryStringParameterExtensions.cs

### DIFF
--- a/OnlineTools/Utils/QueryStringParameterExtensions.cs
+++ b/OnlineTools/Utils/QueryStringParameterExtensions.cs
@@ -63,7 +63,7 @@ namespace OnlineTools.Utils
                     continue;
 
                 var value = property.GetValue(component);
-                if (value is null)
+                if (value is null || (value.GetType() == typeof(string) && string.IsNullOrWhiteSpace(value.ToString())))
                 {
                     parameters.Remove(parameterName);
                 }


### PR DESCRIPTION
A small tweak for how empty parameters get removed from the querystring. In this case, if an empty string is passed in it will also remove the parameter which is a little cleaner when you have multiple parameters that may not be being used.